### PR TITLE
torch.cdist works faster than distance_matrix.

### DIFF
--- a/train.py
+++ b/train.py
@@ -73,7 +73,8 @@ class KNN(NN):
     def predict(self, x):
 
 
-        dist = distance_matrix(x, self.train_pts, self.p) ** (1 / self.p)
+        # dist = distance_matrix(x, self.train_pts, self.p) ** (1 / self.p)
+        dist = torch.cdist(x, self.train_pts, self.p)
 
         knn = dist.topk(self.k, largest=False)
 


### PR DESCRIPTION
and it needs more small gpu-memory.

There is a memory overload in torch.pow(x-y,p).sum()
When I try with this code, I already reserve 8GB and try to allocate another 8GB.

I have a RTX 3080 GPU with 10GB memory.
And when I input big image (3,896,896), distance matrix needs 14.36GB but torch.cdist works well.

It means we can use more large sampling rates by using torch.cdist function.
I can run sampling rate = 0.01 with torch.cdist but I got CUDA out of memory with distance_matrix.

----------------------------------------
Actual GPU memory usages with MVTec AD.
https://github.com/hcw-00/PatchCore_anomaly_detection/issues/19#issuecomment-962706455